### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::SplunkAPI
+# Fluent::Plugin::SplunkAPI, a plugin for [Fluentd](http://fluentd.org)
 
 Splunk output plugin for Fluent event collector.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
