### PR TITLE
Add ned time_format to let Splunk parse the time from the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Put the following lines to your fluent.conf:
       #
 
       # time_format: the time format of each event
-      # value: none, unixtime, localtime, or any time format string
+      # value: none, unixtime, localtime, splunk (to let Splunk parse it from 'time' key) or any time format string
       # default: localtime
       time_format localtime
 

--- a/fluent-plugin-splunkapi.gemspec
+++ b/fluent-plugin-splunkapi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.rubyforge_project = "fluent-plugin-splunkapi"
   gem.add_development_dependency "fluentd"
-  gem.add_development_dependency "net-http-persistent"
+  gem.add_development_dependency "net-http-persistent", "~> 3.0"
   gem.add_runtime_dependency "fluentd"
-  gem.add_runtime_dependency "net-http-persistent"
+  gem.add_runtime_dependency "net-http-persistent", "~> 3.0"
 end


### PR DESCRIPTION
I've added 'time_format splunk' which can use the record['time'] from the source to let Splunk parse the time in the log entry that is sent instead of the corse (second based) time used by the other time_format options which do not represent the actual time the log entry is for. 
PS I'm not a ruby guy, so you are more than welcome to clean up the hack.